### PR TITLE
feat: add product image management and fix seller auth checks

### DIFF
--- a/client/src/components/product-card.tsx
+++ b/client/src/components/product-card.tsx
@@ -129,9 +129,11 @@ export function ProductCard({ product, onClick }: ProductCardProps) {
         <h3 className="font-semibold text-slate-900 mb-1 line-clamp-2">
           {product.name}
         </h3>
-        <p className="text-sm text-muted-foreground mb-2">
-          by {product.brand}
-        </p>
+        {product.brand && (
+          <p className="text-sm text-muted-foreground mb-2">
+            by {product.brand}
+          </p>
+        )}
         
         <div className="flex items-center justify-between mb-3">
           <div className="flex items-center space-x-2">

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -2,6 +2,7 @@ import {
   users,
   sellers,
   products,
+  productImages,
   orders,
   cart,
   payments,
@@ -15,6 +16,8 @@ import {
   type InsertSeller,
   type Product,
   type InsertProduct,
+  type ProductImage,
+  type InsertProductImage,
   type Order,
   type InsertOrder,
   type CartItem,
@@ -66,6 +69,11 @@ export interface IStorage {
   createProduct(product: InsertProduct): Promise<Product>;
   updateProduct(id: string, updates: Partial<Product>): Promise<Product>;
   deleteProduct(id: string): Promise<void>;
+
+  // Product image operations
+  createProductImage(image: InsertProductImage): Promise<ProductImage>;
+  listProductImages(productId: string): Promise<ProductImage[]>;
+  deleteProductImage(id: string): Promise<void>;
 
   // Cart operations
   getCartItems(userId: string): Promise<CartItem[]>;
@@ -497,6 +505,26 @@ export class DatabaseStorage implements IStorage {
 
   async deleteProduct(id: string): Promise<void> {
     await db.delete(products).where(eq(products.id, id));
+  }
+
+  async createProductImage(image: InsertProductImage): Promise<ProductImage> {
+    const [result] = await db
+      .insert(productImages)
+      .values(image)
+      .returning();
+    return result;
+  }
+
+  async listProductImages(productId: string): Promise<ProductImage[]> {
+    return await db
+      .select()
+      .from(productImages)
+      .where(eq(productImages.productId, productId))
+      .orderBy(productImages.displayOrder, productImages.createdAt);
+  }
+
+  async deleteProductImage(id: string): Promise<void> {
+    await db.delete(productImages).where(eq(productImages.id, id));
   }
 
   // Cart operations


### PR DESCRIPTION
## Summary
- add storage and routes for managing product images
- update seller dashboard to persist multiple product images
- fix product ownership validation for seller product updates and deletions
- avoid displaying `by undefined` when product brand is missing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_688de795e4c883238ba6ed9840174c2b