### PR TITLE
fix file-type import for upload route

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -8,7 +8,7 @@ import { setupPassport, getConfiguredProviders } from "./auth";
 import bcrypt from "bcrypt";
 import jwt from "jsonwebtoken";
 import multer from "multer";
-import FileType from "file-type";
+import { fileTypeFromBuffer } from "file-type";
 import path from "path";
 import fs from "fs";
 import {
@@ -148,7 +148,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const fileInfos = [] as any[];
       for (const file of files) {
         const buffer = await fs.promises.readFile(file.path);
-        const detected = await FileType.fromBuffer(buffer);
+        const detected = await fileTypeFromBuffer(buffer);
         fileInfos.push({
           url: `/uploads/${file.filename}`,
           filename: file.filename,


### PR DESCRIPTION
## Summary
- fix file-type usage to match ESM API

## Testing
- `npm test` (fails: Missing script "test")
- `npm run check` (fails: TypeScript errors)
- `npm run dev` & `curl /api/auth/login` (fails: Login failed, ENETUNREACH to database)


------
https://chatgpt.com/codex/tasks/task_e_688dea60dff483239f8cceba7cfcf9ca