### PR TITLE
Switch to pg driver and fix file type import

### DIFF
--- a/server/db.ts
+++ b/server/db.ts
@@ -1,9 +1,6 @@
-import { Pool, neonConfig } from '@neondatabase/serverless';
-import { drizzle } from 'drizzle-orm/neon-serverless';
-import ws from "ws";
-import * as schema from "@shared/schema";
-
-neonConfig.webSocketConstructor = ws;
+import pg from 'pg';
+import { drizzle } from 'drizzle-orm/node-postgres';
+import * as schema from '@shared/schema';
 
 if (!process.env.DATABASE_URL) {
   throw new Error(
@@ -11,5 +8,6 @@ if (!process.env.DATABASE_URL) {
   );
 }
 
+const { Pool } = pg;
 export const pool = new Pool({ connectionString: process.env.DATABASE_URL });
-export const db = drizzle({ client: pool, schema });
+export const db = drizzle(pool, { schema });

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -8,7 +8,7 @@ import { setupPassport, getConfiguredProviders } from "./auth";
 import bcrypt from "bcrypt";
 import jwt from "jsonwebtoken";
 import multer from "multer";
-import FileType from "file-type";
+import { fileTypeFromBuffer } from "file-type";
 import path from "path";
 import fs from "fs";
 import {
@@ -148,7 +148,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const fileInfos = [] as any[];
       for (const file of files) {
         const buffer = await fs.promises.readFile(file.path);
-        const detected = await FileType.fromBuffer(buffer);
+        const detected = await fileTypeFromBuffer(buffer);
         fileInfos.push({
           url: `/uploads/${file.filename}`,
           filename: file.filename,


### PR DESCRIPTION
## Summary
- switch database layer to use `pg` with drizzle for local PostgreSQL connections
- update file upload route to use `fileTypeFromBuffer`

## Testing
- `npm run db:push`
- `curl -i -X POST http://localhost:5000/api/auth/login -H "Content-Type: application/json" -d '{"email":"admin@phonehub.com","password":"admin123"}'`
- `npm run check` *(fails: Property 'id' does not exist on type 'Response', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688deecc3be4832396f77e0fe54004bb