### PR TITLE
Require matching MIME type and extension for uploads

### DIFF
--- a/server/__tests__/upload-filter.test.ts
+++ b/server/__tests__/upload-filter.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import type { Request } from 'express';
+
+let fileFilter: typeof import('../routes').fileFilter;
+
+beforeAll(async () => {
+  process.env.DATABASE_URL = 'postgres://user:pass@localhost:5432/db';
+  ({ fileFilter } = await import('../routes'));
+});
+
+// Helper to run fileFilter and capture callback results
+function runFilter(file: Partial<Express.Multer.File>) {
+  const req = {} as Request;
+  const cb = vi.fn();
+  fileFilter(req, file as Express.Multer.File, cb);
+  return cb;
+}
+
+describe('fileFilter', () => {
+  it('allows files with matching MIME type and extension', () => {
+    const cb = runFilter({ originalname: 'test.jpg', mimetype: 'image/jpeg' });
+    expect(cb).toHaveBeenCalledWith(null, true);
+  });
+
+  it('rejects files with disallowed MIME type or extension', () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const cb = runFilter({ originalname: 'malware.exe', mimetype: 'application/x-msdownload' });
+    expect(cb).toHaveBeenCalled();
+    const errorArg = cb.mock.calls[0][0];
+    expect(errorArg).toBeInstanceOf(Error);
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining('File rejected due to mismatched MIME type or extension')
+    );
+    logSpy.mockRestore();
+  });
+});
+


### PR DESCRIPTION
## Summary
- ensure file uploads pass only when MIME type and extension are both allowed
- log detailed info when uploads are rejected for mismatched type or extension
- add unit tests covering allowed and disallowed file types

## Testing
- `npm test`
- `npm run check` *(fails: TS errors in client pages and missing types for passport-apple)*

------
https://chatgpt.com/codex/tasks/task_e_688df2c8c7dc8323aa4b855629171acc