### PR TITLE
Require JWT_SECRET env var for token handling

### DIFF
--- a/replit.md
+++ b/replit.md
@@ -74,6 +74,12 @@ password: admin123
 
 Logging in with this default account automatically sets up the admin role.
 
+## Setup Instructions
+
+Before running the server, set the required environment variables:
+
+- `JWT_SECRET`: Secret key for signing JSON Web Tokens. The server will fail to start if this variable is not provided.
+
 ## Data Flow
 
 ### Authentication Flow

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -30,7 +30,11 @@ interface AuthenticatedRequest extends Request {
 }
 
 // JWT Authentication middleware
-const JWT_SECRET = process.env.JWT_SECRET || "phonehub-jwt-secret-key-2024";
+const jwtSecret = process.env.JWT_SECRET;
+if (!jwtSecret) {
+  throw new Error("JWT_SECRET environment variable is required");
+}
+const JWT_SECRET = jwtSecret;
 
 // File upload configuration
 const uploadDir = path.join(process.cwd(), 'uploads');


### PR DESCRIPTION
## Summary
- remove fallback JWT secret and abort startup if JWT_SECRET env var is missing
- document required JWT_SECRET variable in setup instructions

## Testing
- `JWT_SECRET=test npm test`
- `npm run check` *(fails: TypeScript errors in client pages)*

------
https://chatgpt.com/codex/tasks/task_e_688df2c9de248323b7a67fcfd677aacc