### PR TITLE
feat: add typed authenticated user

### DIFF
--- a/server/__tests__/sample.test.ts
+++ b/server/__tests__/sample.test.ts
@@ -1,8 +1,16 @@
 import { describe, it, expect } from 'vitest';
+import type { AuthenticatedUser } from '../types';
 
 describe('math', () => {
   it('adds numbers', () => {
     expect(1 + 1).toBe(2);
+  });
+});
+
+describe('types', () => {
+  it('creates an authenticated user object', () => {
+    const user: AuthenticatedUser = { userId: '1', userRole: 'admin' };
+    expect(user.userId).toBe('1');
   });
 });
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -20,14 +20,7 @@ import {
   insertPaymentSchema,
   insertReviewSchema,
 } from "@shared/schema";
-
-interface AuthenticatedRequest extends Request {
-  // Use a loose type for the authenticated user to maintain compatibility
-  // with Express' `Request` interface which defines `user` as `Express.User`.
-  // Specific properties like `userId` and `userRole` can be accessed via
-  // narrowing within route handlers as needed.
-  user?: any;
-}
+import type { AuthenticatedRequest, AuthenticatedUser } from "./types";
 
 // JWT Authentication middleware
 const JWT_SECRET = process.env.JWT_SECRET || "phonehub-jwt-secret-key-2024";
@@ -76,11 +69,11 @@ function authenticateToken(req: AuthenticatedRequest, res: Response, next: NextF
     return res.status(401).json({ message: "Access token required" });
   }
 
-  jwt.verify(token, JWT_SECRET, (err: any, decoded: any) => {
+  jwt.verify(token, JWT_SECRET, (err, decoded) => {
     if (err) {
       return res.status(403).json({ message: "Invalid token" });
     }
-    req.user = decoded as { userId: string; userRole: string };
+    req.user = decoded as AuthenticatedUser;
     next();
   });
 }
@@ -99,12 +92,12 @@ function requireRole(role: string) {
       return res.status(401).json({ message: "Access token required" });
     }
 
-    jwt.verify(token, JWT_SECRET, (err: any, decoded: any) => {
+    jwt.verify(token, JWT_SECRET, (err, decoded) => {
       if (err) {
         return res.status(403).json({ message: "Invalid token" });
       }
-      req.user = decoded as { userId: string; userRole: string };
-      
+      req.user = decoded as AuthenticatedUser;
+
       if (req.user.userRole !== role) {
         return res.status(403).json({ message: "Insufficient permissions" });
       }

--- a/server/types.ts
+++ b/server/types.ts
@@ -1,0 +1,17 @@
+import type { Request } from "express";
+
+export interface AuthenticatedUser {
+  userId: string;
+  userRole: string;
+}
+
+export interface AuthenticatedRequest extends Request {
+  user?: AuthenticatedUser;
+}
+
+declare global {
+  namespace Express {
+    interface User extends AuthenticatedUser {}
+  }
+}
+


### PR DESCRIPTION
## Summary
- define `AuthenticatedUser` and `AuthenticatedRequest` types for JWT-authenticated routes
- ensure JWT middleware populates `req.user` with typed payload
- adjust sample tests to cover new type

## Testing
- `npm test -- --run`
- `npm run check` *(fails: Property 'country' does not exist on type 'object' in client/src/pages/seller-dashboard.tsx...)*

------
https://chatgpt.com/codex/tasks/task_e_688df2cd587883238d4c2ac9d492c28d