### PR TITLE
feat: use generic money icon and KWD formatting

### DIFF
--- a/client/src/pages/admin-panel.tsx
+++ b/client/src/pages/admin-panel.tsx
@@ -27,7 +27,7 @@ import {
   Users,
   ShoppingBag,
   TrendingUp,
-  DollarSign,
+  Coins,
   Eye,
   Settings,
   AlertCircle,
@@ -491,7 +491,7 @@ export default function AdminPanel() {
                           )}
                         </p>
                       </div>
-                      <DollarSign className="h-8 w-8 text-green-600" />
+                      <Coins className="h-8 w-8 text-green-600" />
                     </div>
                   </CardContent>
                 </Card>

--- a/client/src/pages/pos-system.tsx
+++ b/client/src/pages/pos-system.tsx
@@ -11,7 +11,7 @@ import { useLanguage } from "@/contexts/LanguageContext";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useToast } from "@/hooks/use-toast";
 import { apiRequest } from "@/lib/queryClient";
-import { Search, Plus, Minus, Trash2, CreditCard, DollarSign, Package, Receipt as ReceiptIcon } from "lucide-react";
+import { Search, Plus, Minus, Trash2, CreditCard, Coins, Package, Receipt as ReceiptIcon } from "lucide-react";
 import type { Product, Order } from "@shared/schema";
 
 interface POSCartItem {
@@ -383,7 +383,7 @@ export default function POSSystem() {
                     onClick={() => processPayment("cash")}
                     disabled={createPOSOrderMutation.isPending || posCart.length === 0}
                   >
-                    <DollarSign className="h-4 w-4 mr-2" />
+                    <Coins className="h-4 w-4 mr-2" />
                     {t('cash_payment')}
                   </Button>
                   <Button 

--- a/client/src/pages/seller-dashboard.tsx
+++ b/client/src/pages/seller-dashboard.tsx
@@ -14,7 +14,7 @@ import { useAuth } from "@/hooks/useAuth";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useToast } from "@/hooks/use-toast";
 import { apiRequest } from "@/lib/queryClient";
-import { DollarSign, Package, Clock, Star, Plus, Edit, Trash2, BarChart3, Bell, CheckCircle, XCircle, AlertCircle, ShoppingCart } from "lucide-react";
+import { Coins, Package, Clock, Star, Plus, Edit, Trash2, BarChart3, Bell, CheckCircle, XCircle, AlertCircle, ShoppingCart } from "lucide-react";
 import { useLanguage } from "@/contexts/LanguageContext";
 import { FileUpload } from "@/components/file-upload";
 import type { Product, Order, Seller } from "@shared/schema";
@@ -263,11 +263,11 @@ export default function SellerDashboard() {
                 <div>
                   <p className="text-sm text-slate-600">Total Sales</p>
                   <p className="text-2xl font-bold text-slate-900">
-                    ${stats?.totalSales || "0"}
+                    {formatCurrency(parseFloat(stats?.totalSales || "0"))}
                   </p>
                 </div>
                 <div className="w-12 h-12 bg-secondary/10 rounded-lg flex items-center justify-center">
-                  <DollarSign className="h-6 w-6 text-secondary" />
+                  <Coins className="h-6 w-6 text-secondary" />
                 </div>
               </div>
             </CardContent>
@@ -731,7 +731,7 @@ export default function SellerDashboard() {
                               <div className="flex items-center gap-2">
                                 {order.isPosOrder ? (
                                   <>
-                                    <DollarSign className="h-4 w-4 text-green-600" />
+                                    <Coins className="h-4 w-4 text-green-600" />
                                     <span className="text-sm font-medium">Cash (POS)</span>
                                   </>
                                 ) : (
@@ -808,7 +808,7 @@ export default function SellerDashboard() {
                               {stats ? formatCurrency(stats.totalSales) : formatCurrency(0)}
                             </p>
                           </div>
-                          <DollarSign className="h-8 w-8 text-green-600" />
+                          <Coins className="h-8 w-8 text-green-600" />
                         </div>
                       </CardContent>
                     </Card>


### PR DESCRIPTION
## Summary
- replace DollarSign icons with generic Coins icon across dashboards and POS
- format seller totals using formatCurrency for KWD

## Testing
- `JWT_SECRET=test-secret npm test`

------
https://chatgpt.com/codex/tasks/task_e_688dfc1210b08323a97dbf33271eddc8