### PR TITLE
feat: add dark mode theme provider

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,6 +4,7 @@ import { QueryClientProvider } from "@tanstack/react-query";
 import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { LanguageProvider } from "@/contexts/LanguageContext";
+import { ThemeProvider } from "@/contexts/ThemeContext";
 import { useAuth } from "@/hooks/useAuth";
 import NotFound from "@/pages/not-found";
 import Marketplace from "@/pages/marketplace";
@@ -81,10 +82,12 @@ function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <LanguageProvider>
-        <TooltipProvider>
-          <Toaster />
-          <Router />
-        </TooltipProvider>
+        <ThemeProvider>
+          <TooltipProvider>
+            <Toaster />
+            <Router />
+          </TooltipProvider>
+        </ThemeProvider>
       </LanguageProvider>
     </QueryClientProvider>
   );

--- a/client/src/components/navigation.tsx
+++ b/client/src/components/navigation.tsx
@@ -5,6 +5,7 @@ import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
 import { LanguageToggle } from "@/components/language-toggle";
+import { ThemeToggle } from "@/components/theme-toggle";
 import { useLanguage } from "@/contexts/LanguageContext";
 import { useAuth } from "@/hooks/useAuth";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
@@ -177,7 +178,7 @@ export function Navigation() {
   };
 
   return (
-    <header className="bg-white shadow-sm border-b border-slate-200 sticky top-0 z-50">
+    <header className="bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 shadow-sm border-b border-slate-200 dark:border-slate-700 sticky top-0 z-50">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center h-16">
           {/* Logo and Brand */}
@@ -206,6 +207,7 @@ export function Navigation() {
           <div className={`flex items-center ${isRTL ? 'space-x-reverse' : ''} space-x-4`}>
             {/* Language Toggle */}
             <LanguageToggle />
+            <ThemeToggle />
             {/* Cart */}
             {isAuthenticated && (
               <Sheet open={isCartOpen} onOpenChange={setIsCartOpen}>

--- a/client/src/components/theme-toggle.tsx
+++ b/client/src/components/theme-toggle.tsx
@@ -1,0 +1,25 @@
+import { Button } from '@/components/ui/button';
+import { useTheme } from '@/contexts/ThemeContext';
+import { Moon, Sun } from 'lucide-react';
+
+export function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme();
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={toggleTheme}
+      className="flex items-center gap-2"
+    >
+      {theme === 'dark' ? (
+        <Sun className="h-4 w-4" />
+      ) : (
+        <Moon className="h-4 w-4" />
+      )}
+      <span className="text-sm font-medium">
+        {theme === 'dark' ? 'Light' : 'Dark'}
+      </span>
+    </Button>
+  );
+}

--- a/client/src/contexts/ThemeContext.tsx
+++ b/client/src/contexts/ThemeContext.tsx
@@ -1,0 +1,46 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+type Theme = 'light' | 'dark';
+
+interface ThemeContextType {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useState<Theme>(() => {
+    if (typeof window === 'undefined') return 'light';
+    const saved = localStorage.getItem('theme') as Theme | null;
+    if (saved === 'light' || saved === 'dark') return saved;
+    return 'light';
+  });
+
+  useEffect(() => {
+    const root = window.document.documentElement;
+    if (theme === 'dark') {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+    }
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => setTheme((prev) => (prev === 'dark' ? 'light' : 'dark'));
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+}
+

--- a/client/src/pages/seller-dashboard.tsx
+++ b/client/src/pages/seller-dashboard.tsx
@@ -241,13 +241,13 @@ export default function SellerDashboard() {
   // For simplified implementation, all sellers are considered approved
 
   return (
-    <div className="min-h-screen bg-slate-50">
+    <div className="min-h-screen bg-slate-50 dark:bg-slate-900 text-slate-900 dark:text-slate-100">
       <Navigation />
-      
+
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <div className="text-center mb-12">
-          <h1 className="text-3xl font-bold text-slate-900 mb-4">Seller Dashboard</h1>
-          <p className="text-lg text-slate-600">Manage your products and track performance</p>
+          <h1 className="text-3xl font-bold text-slate-900 dark:text-slate-100 mb-4">Seller Dashboard</h1>
+          <p className="text-lg text-slate-600 dark:text-slate-300">Manage your products and track performance</p>
         </div>
 
         {/* Seller Onboarding Status */}


### PR DESCRIPTION
## Summary
- add `ThemeProvider` to manage light/dark modes and persist preference
- add `ThemeToggle` and expose in navigation
- apply dark mode styles to seller dashboard and navigation containers

## Testing
- `JWT_SECRET=test npm test`

------
https://chatgpt.com/codex/tasks/task_e_688dfc14b0d483239f7bfd6d24a70096