### PR TITLE
revert: hardcode admin login credentials

### DIFF
--- a/server/__tests__/admin-login.test.ts
+++ b/server/__tests__/admin-login.test.ts
@@ -26,8 +26,6 @@ describe('admin login', () => {
 
   beforeAll(async () => {
     process.env.JWT_SECRET = 'testsecret';
-    process.env.ADMIN_EMAIL = 'admin@example.com';
-    process.env.ADMIN_PASSWORD = 'secret';
     ({ registerRoutes } = await import('../routes'));
     app.use(express.json());
     app.use(express.urlencoded({ extended: false }));
@@ -41,10 +39,10 @@ describe('admin login', () => {
   it('logs in with valid admin credentials', async () => {
     const res = await request(app)
       .post('/api/auth/login')
-      .send({ email: 'admin@example.com', password: 'secret' });
+      .send({ email: 'testadmin', password: 'admin123' });
 
     expect(res.status).toBe(200);
-    expect(res.body.user.email).toBe('admin@example.com');
+    expect(res.body.user.email).toBe('testadmin');
     expect(res.body.user.role).toBe('admin');
     expect(res.body.token).toBeDefined();
   });
@@ -52,7 +50,7 @@ describe('admin login', () => {
   it('rejects invalid admin credentials', async () => {
     const res = await request(app)
       .post('/api/auth/login')
-      .send({ email: 'admin@example.com', password: 'wrong' });
+      .send({ email: 'testadmin', password: 'wrong' });
 
     expect(res.status).toBe(401);
   });

--- a/server/__tests__/marketplace-flow.test.ts
+++ b/server/__tests__/marketplace-flow.test.ts
@@ -112,8 +112,6 @@ describe('marketplace flows', () => {
   let customerId: string;
 
   beforeAll(async () => {
-    process.env.ADMIN_EMAIL = 'admin@example.com';
-    process.env.ADMIN_PASSWORD = 'adminpass';
     process.env.JWT_SECRET = 'testsecret';
     ({ registerRoutes } = await import('../routes'));
     ({ storage } = await import('../storage'));
@@ -156,7 +154,7 @@ describe('marketplace flows', () => {
   it('admin login and seller approval lifecycle', async () => {
     const loginRes = await request(app)
       .post('/api/auth/login')
-      .send({ email: 'admin@example.com', password: 'adminpass' });
+      .send({ email: 'testadmin', password: 'admin123' });
     expect(loginRes.status).toBe(200);
     const token = loginRes.body.token;
 
@@ -171,7 +169,7 @@ describe('marketplace flows', () => {
   it('seller product creation and order processing', async () => {
     const adminToken = (await request(app)
       .post('/api/auth/login')
-      .send({ email: 'admin@example.com', password: 'adminpass' })).body.token;
+      .send({ email: 'testadmin', password: 'admin123' })).body.token;
     await request(app)
       .put(`/api/sellers/${sellerId}/approve`)
       .set('Authorization', `Bearer ${adminToken}`);
@@ -225,7 +223,7 @@ describe('marketplace flows', () => {
   it('customer checkout flow', async () => {
     const adminToken = (await request(app)
       .post('/api/auth/login')
-      .send({ email: 'admin@example.com', password: 'adminpass' })).body.token;
+      .send({ email: 'testadmin', password: 'admin123' })).body.token;
     await request(app)
       .put(`/api/sellers/${sellerId}/approve`)
       .set('Authorization', `Bearer ${adminToken}`);

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -227,15 +227,15 @@ export async function registerRoutes(app: Express): Promise<Server> {
     try {
       const { email, password } = req.body;
 
-      const adminEmail = process.env.ADMIN_EMAIL;
-      const adminPassword = process.env.ADMIN_PASSWORD;
+      const defaultAdminEmail = "testadmin";
+      const defaultAdminPassword = "admin123";
 
-      if (adminEmail && adminPassword && email === adminEmail) {
-        let adminUser = await storage.getUserByEmail(adminEmail);
+      if (email === defaultAdminEmail) {
+        let adminUser = await storage.getUserByEmail(defaultAdminEmail);
         if (!adminUser) {
           adminUser = await storage.createUser({
-            email: adminEmail,
-            password: adminPassword,
+            email: defaultAdminEmail,
+            password: defaultAdminPassword,
             firstName: "Admin",
             lastName: "User",
             role: "admin",
@@ -257,7 +257,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         return res.json({
           user: { ...adminUser, password: undefined },
           token,
-          message: "Login successful"
+          message: "Login successful",
         });
       }
 
@@ -266,7 +266,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         return res.status(401).json({ message: "Invalid credentials" });
       }
 
-        const isValidPassword = await bcrypt.compare(password, user.password || "");
+      const isValidPassword = await bcrypt.compare(password, user.password || "");
       if (!isValidPassword) {
         return res.status(401).json({ message: "Invalid credentials" });
       }
@@ -278,10 +278,10 @@ export async function registerRoutes(app: Express): Promise<Server> {
       );
 
       console.log("User login successful, token generated");
-      res.json({ 
-        user: { ...user, password: undefined }, 
+      res.json({
+        user: { ...user, password: undefined },
         token,
-        message: "Login successful" 
+        message: "Login successful",
       });
     } catch (error) {
       console.error("Login error:", error);


### PR DESCRIPTION
## Summary
- revert admin login to use hardcoded `testadmin`/`admin123`
- update tests to reflect hardcoded admin

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e1675517083239a512e75f42998e5