### PR TITLE
feat: add seller notification settings

### DIFF
--- a/docs/AI_ASSISTANT.md
+++ b/docs/AI_ASSISTANT.md
@@ -5,3 +5,9 @@
 - **Apply Filters** button: triggers a refresh of the product list using the current filter selections.
 - **Wishlist** heart buttons: let users toggle items in a local wishlist stored in the browser. No server-side persistence yet.
 
+## Seller Dashboard
+
+- **Open POS System** button: opens the POS interface for in-store sales.
+- Notification toggle buttons: let sellers enable or disable email, SMS, and low-stock alerts. These preferences can be saved, but actual notification delivery is still a placeholder.
+- **Save Settings** button: persists the selected notification preferences to the backend.
+

--- a/migrations/0002_seller_notification_prefs.sql
+++ b/migrations/0002_seller_notification_prefs.sql
@@ -1,0 +1,5 @@
+-- 0002_seller_notification_prefs.sql
+ALTER TABLE sellers
+  ADD COLUMN email_notifications BOOLEAN NOT NULL DEFAULT true,
+  ADD COLUMN sms_notifications BOOLEAN NOT NULL DEFAULT true,
+  ADD COLUMN low_stock_alerts BOOLEAN NOT NULL DEFAULT true;

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -899,6 +899,48 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
+  // Seller notification settings
+  app.get("/api/sellers/settings", requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+    try {
+      const seller = await storage.getSellerByUserId(req.user!.userId);
+      if (!seller) {
+        return res.status(404).json({ message: "Seller profile not found" });
+      }
+      res.json({
+        emailNotifications: seller.emailNotifications,
+        smsNotifications: seller.smsNotifications,
+        lowStockAlerts: seller.lowStockAlerts,
+      });
+    } catch (error) {
+      console.error("Get seller settings error:", error);
+      res.status(500).json({ message: "Failed to get seller settings" });
+    }
+  });
+
+  app.put("/api/sellers/settings", requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+    try {
+      const seller = await storage.getSellerByUserId(req.user!.userId);
+      if (!seller) {
+        return res.status(404).json({ message: "Seller profile not found" });
+      }
+
+      const updated = await storage.updateSeller(seller.sellerId, {
+        emailNotifications: req.body.emailNotifications,
+        smsNotifications: req.body.smsNotifications,
+        lowStockAlerts: req.body.lowStockAlerts,
+      });
+
+      res.json({
+        emailNotifications: updated.emailNotifications,
+        smsNotifications: updated.smsNotifications,
+        lowStockAlerts: updated.lowStockAlerts,
+      });
+    } catch (error) {
+      console.error("Update seller settings error:", error);
+      res.status(500).json({ message: "Failed to update seller settings" });
+    }
+  });
+
   // Admin routes for document management
   app.get("/api/admin/sellers/documents", requireRole("admin"), async (req: Request, res: Response, next: NextFunction) => {
     try {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -221,6 +221,9 @@ export class DatabaseStorage implements IStorage {
           ownerCivilId: sellers.ownerCivilId,
           businessAddress: sellers.businessAddress,
           whatsappNumber: sellers.whatsappNumber,
+          emailNotifications: sellers.emailNotifications,
+          smsNotifications: sellers.smsNotifications,
+          lowStockAlerts: sellers.lowStockAlerts,
           // Document fields
           businessLogo: sellers.businessLogo,
           shopLicenseImage: sellers.shopLicenseImage,

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -108,6 +108,10 @@ export const sellers = pgTable("sellers", {
   emiratesId: varchar("emirates_id"),
   passportNumber: varchar("passport_number"),
 
+  emailNotifications: boolean("email_notifications").notNull().default(true),
+  smsNotifications: boolean("sms_notifications").notNull().default(true),
+  lowStockAlerts: boolean("low_stock_alerts").notNull().default(true),
+
   // Branding
   businessLogo: varchar("business_logo"),
   businessEmail: varchar("business_email"),


### PR DESCRIPTION
## Summary
- document seller dashboard actions including POS link, notification toggles, and saving
- allow sellers to toggle notification preferences and save them
- expose backend endpoints and database fields for seller notification settings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f9bb941ac8323b3c27b44ded694e1