### PR TITLE
Add placeholder quick action navigation

### DIFF
--- a/client/src/pages/customer-dashboard.tsx
+++ b/client/src/pages/customer-dashboard.tsx
@@ -7,10 +7,12 @@ import { useQuery } from "@tanstack/react-query";
 import { Package, ShoppingBag, Heart, User } from "lucide-react";
 import type { Order } from "@shared/schema";
 import { useLanguage } from "@/contexts/LanguageContext";
+import { useLocation } from "wouter";
 
 export default function CustomerDashboard() {
   const { user } = useAuth();
   const { formatCurrency } = useLanguage();
+  const [, setLocation] = useLocation();
 
   const { data: orders = [] } = useQuery<Order[]>({
     queryKey: ["/api/orders"],
@@ -137,15 +139,27 @@ export default function CustomerDashboard() {
                 <CardTitle>Quick Actions</CardTitle>
               </CardHeader>
               <CardContent className="space-y-3">
-                <Button className="w-full" variant="outline">
+                <Button
+                  className="w-full"
+                  variant="outline"
+                  onClick={() => setLocation("/orders")}
+                >
                   <Package className="h-4 w-4 mr-2" />
                   Track Order
                 </Button>
-                <Button className="w-full" variant="outline">
+                <Button
+                  className="w-full"
+                  variant="outline"
+                  onClick={() => setLocation("/wishlist")}
+                >
                   <Heart className="h-4 w-4 mr-2" />
                   View Wishlist
                 </Button>
-                <Button className="w-full" variant="outline">
+                <Button
+                  className="w-full"
+                  variant="outline"
+                  onClick={() => setLocation("/profile")}
+                >
                   <User className="h-4 w-4 mr-2" />
                   Update Profile
                 </Button>

--- a/docs/AI_ASSISTANT.md
+++ b/docs/AI_ASSISTANT.md
@@ -11,3 +11,7 @@
 - Notification toggle buttons: let sellers enable or disable email, SMS, and low-stock alerts. These preferences can be saved, but actual notification delivery is still a placeholder.
 - **Save Settings** button: persists the selected notification preferences to the backend.
 
+## Customer Dashboard
+
+- Quick action buttons ("Track Order," "View Wishlist," and "Update Profile") currently navigate to placeholder routes and do not yet provide full functionality.
+


### PR DESCRIPTION
## Summary
- document that customer dashboard quick actions are currently placeholders
- wire up customer dashboard quick action buttons to placeholder routes for tracking orders, viewing wishlist, and updating profile

## Testing
- `npm test`
- `npm run check` *(fails: Property 'totalSales' does not exist on type '{}', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688fa1a2868c8323926b0e255cd82c94