### PR TITLE
Add personalized product recommendations

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -18,6 +18,7 @@ import AdminPanel from "@/pages/admin-panel";
 import POSSystem from "@/pages/pos-system";
 import Checkout from "@/pages/checkout";
 import Loyalty from "@/pages/loyalty";
+import Home from "@/pages/home";
 
 function Router() {
   const { isLoading } = useAuth();
@@ -33,7 +34,7 @@ function Router() {
   return (
     <Switch>
       {/* Public routes */}
-      <Route path="/" component={Marketplace} />
+      <Route path="/" component={Home} />
       <Route path="/marketplace" component={Marketplace} />
       <Route path="/product/:id" component={ProductDetails} />
       

--- a/client/src/hooks/useRecommendations.ts
+++ b/client/src/hooks/useRecommendations.ts
@@ -1,0 +1,23 @@
+import { useQuery } from "@tanstack/react-query";
+import type { Product } from "@shared/schema";
+
+export function useRecommendations(limit = 5) {
+  return useQuery<Product[]>({
+    queryKey: ["/api/recommendations", limit],
+    queryFn: async () => {
+      const token = localStorage.getItem("authToken");
+      if (!token) return [];
+      const res = await fetch(`/api/recommendations?limit=${limit}`, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+      if (!res.ok) {
+        throw new Error("Failed to fetch recommendations");
+      }
+      return res.json();
+    },
+    enabled: !!localStorage.getItem("authToken"),
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -1,0 +1,32 @@
+import { Navigation } from "@/components/navigation";
+import { ProductCard } from "@/components/product-card";
+import { useRecommendations } from "@/hooks/useRecommendations";
+import { useLocation } from "wouter";
+
+export default function Home() {
+  const [, setLocation] = useLocation();
+  const { data: products = [] } = useRecommendations(10);
+
+  return (
+    <div className="min-h-screen bg-slate-50">
+      <Navigation />
+      <div className="container mx-auto px-4 py-8">
+        {products.length > 0 && (
+          <>
+            <h2 className="text-2xl font-bold mb-4">Recommended for you</h2>
+            <div className="flex gap-4 overflow-x-auto pb-4">
+              {products.map((p) => (
+                <div key={p.id} className="w-64 flex-shrink-0">
+                  <ProductCard
+                    product={p}
+                    onClick={() => setLocation(`/product/${p.id}`)}
+                  />
+                </div>
+              ))}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/product-details.tsx
+++ b/client/src/pages/product-details.tsx
@@ -11,6 +11,8 @@ import { useToast } from "@/hooks/use-toast";
 import { useAuth } from "@/hooks/useAuth";
 import { apiRequest } from "@/lib/queryClient";
 import ChatWidget from "@/components/chat-widget";
+import { useRecommendations } from "@/hooks/useRecommendations";
+import { ProductCard } from "@/components/product-card";
 
 export default function ProductDetails() {
   const [, params] = useRoute("/product/:id");
@@ -55,6 +57,8 @@ export default function ProductDetails() {
       });
     },
   });
+
+  const { data: recommended = [] } = useRecommendations(8);
 
   const handleAddToCart = () => {
     if (!user) {
@@ -231,6 +235,24 @@ export default function ProductDetails() {
             </Button>
           </div>
         </div>
+
+        {recommended.filter((p) => p.id !== productId).length > 0 && (
+          <div className="mb-8">
+            <h2 className="text-2xl font-bold mb-4">Recommended for you</h2>
+            <div className="flex gap-4 overflow-x-auto pb-4">
+              {recommended
+                .filter((p) => p.id !== productId)
+                .map((p) => (
+                  <div key={p.id} className="w-64 flex-shrink-0">
+                    <ProductCard
+                      product={p}
+                      onClick={() => setLocation(`/product/${p.id}`)}
+                    />
+                  </div>
+                ))}
+            </div>
+          </div>
+        )}
 
         {/* Seller Information */}
         {product.seller && (

--- a/server/recommendations.ts
+++ b/server/recommendations.ts
@@ -1,0 +1,28 @@
+import { db } from "./db";
+import { userEvents } from "@shared/schema";
+import { and, eq, gt } from "drizzle-orm";
+
+const EVENT_WEIGHTS = {
+  view: 1,
+  cart_add: 3,
+  purchase: 5,
+};
+
+export async function getRecommendations(userId: string, limit = 5) {
+  const since = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000); // last 30 days
+  const events = await db
+    .select()
+    .from(userEvents)
+    .where(and(eq(userEvents.userId, userId), gt(userEvents.createdAt, since)));
+
+  const scores: Record<string, number> = {};
+  for (const event of events) {
+    const weight = EVENT_WEIGHTS[event.eventType as keyof typeof EVENT_WEIGHTS] || 0;
+    scores[event.productId] = (scores[event.productId] || 0) + weight;
+  }
+
+  return Object.entries(scores)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, limit)
+    .map(([productId]) => productId);
+}


### PR DESCRIPTION
## Summary
- Track view, cart, and purchase events in new `user_events` table
- Aggregate events via recommendations service and expose `/api/recommendations`
- Fetch and render personalized product carousels on Home and Product Details pages

## Testing
- `npm test` *(fails: DATABASE_URL must be set)*

------
https://chatgpt.com/codex/tasks/task_e_688fe2b722fc8323aea7b2e5a56fcd7b