### PR TITLE
feat: add admin settings state

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1245,12 +1245,11 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
   app.put("/api/admin/settings", requireRole("admin"), async (req: Request, res: Response, next: NextFunction) => {
     try {
-      if (req.body.notification_email) {
-        await storage.setAdminSetting(
-          "notification_email", 
-          req.body.notification_email,
-          "Email address for admin notifications"
-        );
+      const settings = req.body as Record<string, unknown>;
+      for (const [key, value] of Object.entries(settings)) {
+        if (typeof value === "string") {
+          await storage.setAdminSetting(key, value, `Admin setting ${key}`);
+        }
       }
       res.json({ success: true });
     } catch (error) {


### PR DESCRIPTION
## Summary
- manage admin settings in client state and update via API
- wire up save settings button to persist and refresh settings
- allow server route to handle arbitrary admin settings keys

## Testing
- `npm test -- --run` *(fails: DATABASE_URL must be set)*

------
https://chatgpt.com/codex/tasks/task_e_688fe75386e88323acf270243e4248ff